### PR TITLE
test: add simple CLI tests + validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ Demo Video
 > Notă: Video-ul arată funcționalitățile principale ale aplicației într-o prezentare rapidă.
 
 ---
+## Automated Tests
+
+These are simple CLI tests (no PHPUnit).
+
+How to run:
+```bash
+php tests/validation_test.php
+php tests/db_smoke.php
+
+Expected output (examples):
+
+OK  - Empty title should error
+OK  - Non-numeric year should error
+OK  - Future year should error
+OK  - Valid data should have no errors
+Passed: 4, Failed: 0
+
+DB OK
+
+tests/validation_test.php
+
+tests/db_smoke.php
 
 Structura proiectului
 Library_Project/

--- a/lib/validation.php
+++ b/lib/validation.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Validate book input data.
+ * Returns an array of error messages (empty if valid).
+ *
+ * @param array $data
+ * @return string[]
+ */
+function validate_book_input(array $data): array {
+    $errors = [];
+
+    $title          = trim($data['title'] ?? '');
+    $author         = trim($data['author'] ?? '');
+    $genre          = trim($data['genre'] ?? '');
+    $published_year = trim($data['published_year'] ?? '');
+
+    if ($title === '')  { $errors[] = 'Title is required.'; }
+    if ($author === '') { $errors[] = 'Author is required.'; }
+    if ($genre === '')  { $errors[] = 'Genre is required.'; }
+
+    $currentYear = (int)date('Y');
+    if ($published_year === '' || !ctype_digit($published_year)) {
+        $errors[] = 'Published year must be a number.';
+    } else {
+        $py = (int)$published_year;
+        if ($py < 1000 || $py > $currentYear) {
+            $errors[] = 'Published year must be between 1000 and ' . $currentYear . '.';
+        }
+    }
+
+    return $errors;
+}

--- a/tests/db_smoke.php
+++ b/tests/db_smoke.php
@@ -1,0 +1,25 @@
+<?php
+// tests/db_smoke.php
+require __DIR__ . '/../database.php';
+
+try {
+    $pdo = db();
+    if (!($pdo instanceof PDO)) {
+        throw new RuntimeException('db() did not return a PDO instance');
+    }
+
+    // Pick a simple query based on driver (Oracle needs DUAL)
+    $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    $sql = in_array($driver, ['oci', 'oci8']) ? 'SELECT 1 FROM DUAL' : 'SELECT 1';
+
+    $stmt = $pdo->query($sql);
+    if ($stmt === false) {
+        throw new RuntimeException('Simple SELECT 1 query failed');
+    }
+
+    echo "DB OK\n";
+    exit(0);
+} catch (Throwable $e) {
+    echo "DB ERROR: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/tests/validation_test.php
+++ b/tests/validation_test.php
@@ -1,0 +1,51 @@
+<?php
+// tests/validation_test.php
+require __DIR__ . '/../lib/validation.php';
+
+function contains_msg(array $errors, string $needle): bool {
+    foreach ($errors as $e) {
+        if (strpos($e, $needle) !== false) return true;
+    }
+    return false;
+}
+
+$cases = [
+    [
+        'name' => 'Empty title should error',
+        'data' => ['title' => '', 'author' => 'A', 'genre' => 'G', 'published_year' => (string)date('Y')],
+        'expect' => function($errs) { return in_array('Title is required.', $errs, true); }
+    ],
+    [
+        'name' => 'Non-numeric year should error',
+        'data' => ['title' => 'T', 'author' => 'A', 'genre' => 'G', 'published_year' => 'abcd'],
+        'expect' => function($errs) { return contains_msg($errs, 'must be a number'); }
+    ],
+    [
+        'name' => 'Future year should error',
+        'data' => ['title' => 'T', 'author' => 'A', 'genre' => 'G', 'published_year' => (string)(date('Y') + 1)],
+        'expect' => function($errs) { return contains_msg($errs, 'between 1000'); }
+    ],
+    [
+        'name' => 'Valid data should have no errors',
+        'data' => ['title' => 'T', 'author' => 'A', 'genre' => 'G', 'published_year' => (string)date('Y')],
+        'expect' => function($errs) { return count($errs) === 0; }
+    ],
+];
+
+$passed = 0; $failed = 0;
+
+foreach ($cases as $case) {
+    $errors = validate_book_input($case['data']);
+    $ok = $case['expect']($errors);
+
+    if ($ok) {
+        $passed++;
+        echo "OK  - " . $case['name'] . PHP_EOL;
+    } else {
+        $failed++;
+        echo "FAIL - " . $case['name'] . " | got: " . implode('; ', $errors) . PHP_EOL;
+    }
+}
+
+echo "Passed: $passed, Failed: $failed" . PHP_EOL;
+exit($failed > 0 ? 1 : 0);


### PR DESCRIPTION
Adds:
- lib/validation.php (centralized input checks)
- tests/validation_test.php (basic validation cases)
- tests/db_smoke.php (PDO + simple SELECT test)
- README section: how to run the tests

Purpose: make it easy to verify input rules and DB connectivity from CLI.
